### PR TITLE
Locking down mandrill-bundle dep to 1.x release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
-        "hipaway-travel/mandrill-bundle": "dev-master"
+        "hipaway-travel/mandrill-bundle": "~1.0"
     },
     "autoload": {
         "psr-0": { "Wrep\\FOSUserBundleMandrillMailer": "" }


### PR DESCRIPTION
- Ensure no breaking changes are pulled in when loading mandrill-bundle dependency.
